### PR TITLE
Fix missing loading of calendar asset

### DIFF
--- a/install/etc/cont-init.d/40-kopano-webservices
+++ b/install/etc/cont-init.d/40-kopano-webservices
@@ -24,6 +24,7 @@ fi
 
 ### Calendar Config
 if var_true "${ENABLE_CALENDAR}" ; then
+	source /assets/defaults/kopano-calendar
 	source /assets/defaults/kopano-server
 	configure_calendar
 fi


### PR DESCRIPTION
Calendar default/user variables are not loaded from assets before configuration phase begins.